### PR TITLE
Fixed #37. Don't allow banned users from logging in.

### DIFF
--- a/minion/frontend/static/js/minion-main.js
+++ b/minion/frontend/static/js/minion-main.js
@@ -4,7 +4,7 @@
 
 var app = angular.module("MinionApp", ["ui.bootstrap", "minionAdminPlansModule", "minionAdminSitesModule", "minionAdminPluginsModule"]);
 
-app.controller("MinionController", function($rootScope, $http, $location) {
+app.controller("MinionController", function($rootScope, $scope, $http, $location) {
     if (sessionStorage.getItem("email")) {
         $rootScope.session = {email: sessionStorage.getItem("email"), role: sessionStorage.getItem("role")};
     } else {
@@ -16,12 +16,14 @@ app.controller("MinionController", function($rootScope, $http, $location) {
     onlogin: function(assertion) {
             $http.post('/api/login', {assertion: assertion, invite_id: $rootScope.inviteId})
                 .success(function(response, status, headers, config) {
-                    console.log(response);
                     if (response.success) {
                         $rootScope.session = response.data;
                         sessionStorage.setItem("email", response.data.email);
                         sessionStorage.setItem("role", response.data.role);
                         $location.path("/home/sites").replace();
+                    } else {
+                        $scope.logInStatus = response.reason;
+                        $location.path("/login").replace();
                     }
                 $rootScope.inviteId = null;
                 });
@@ -108,10 +110,7 @@ app.run(function($rootScope, $http, $location) {
         // make  /invites/:inviteId into a whitelist
         has_invite = $location.url().substring().split('/')[1] == "invite"
         if (!has_invite && !$rootScope.session) {
-            console.log($location.url())
-            console.log("inside 1")
             if (next.$$route.templateUrl !== "static/partials/login.html" ) {
-                console.log("inside 2")
                 $location.path("/login");
             }
         }

--- a/minion/frontend/static/partials/login.html
+++ b/minion/frontend/static/partials/login.html
@@ -8,6 +8,9 @@
   <form class="form-signin" id="signin-form">
     <h2 class="form-signin-heading">Welcome to Minion</h2>
     <p><b>Note:</b> This application requires Persona to sign in.</p>
+    <div class="alert alert-error" ng-show="logInStatus == 'banned'">
+        <b>Oh snap!</b> You are banned so you cannot proceed to login.
+    </div>
     <p><a class="btn btn-large btn-primary" ng-click="signIn()" href="#"><i class="icon-user"></i> Sign in with Persona</a></p>
   </form>
 </div>

--- a/minion/frontend/views.py
+++ b/minion/frontend/views.py
@@ -362,6 +362,8 @@ def persona_login():
         user = get_or_create_user(receipt['email'])
     if not user:
         return jsonify(success=False)
+    elif user.get('status') == "banned":
+        return jsonify(success=False, reason="banned")
     session['email'] = user['email']
     session['role'] = user['role']
     return api_session()


### PR DESCRIPTION
We use the user json returned from backend to decide whether user should log in or not. If user is banned, we don't allow user to enter. Send them back to login page with a brief line stating they are banned.
