### PR TITLE
Fixed #66. If scan hasn't started, show '---' instead of 44 years ago or...

### DIFF
--- a/minion/frontend/static/js/minion-main.js
+++ b/minion/frontend/static/js/minion-main.js
@@ -331,17 +331,20 @@ app.filter('moment', function () {
 
 app.filter('scan_datetime', function () {
     return function(input, options) {
-        if (input) {
+        if (input > 0) {
             return moment.unix(input).format("YYYY-MM-DD HH:mm");
         } else {
-            return "Never";
+            return "---";
         }
     };
 });
 
 app.filter('scan_datetime_fromnow', function () {
     return function(input, options) {
-        return moment.unix(input).fromNow();
+        if (input > 0)
+            return moment.unix(input).fromNow();
+        else
+            return;
     };
 });
 

--- a/minion/frontend/static/partials/scan.html
+++ b/minion/frontend/static/partials/scan.html
@@ -24,7 +24,12 @@
           </tr>
           <tr>
             <td><b>Started</b></td>
-            <td>{{scan.sessions[0].started | scan_datetime }} ({{scan.sessions[0].started | scan_datetime_fromnow }})</td>
+            <td ng-show="scan.sessions[0].started">
+            {{scan.sessions[0].started | scan_datetime }} ({{scan.sessions[0].started | scan_datetime_fromnow }})
+            </td>
+            <td ng-show="!scan.sessions[0].started">
+            {{scan.sessions[0].started | scan_datetime }}
+            </td>
           </tr>
           <tr>
             <td><b>State</b></td>


### PR DESCRIPTION
... never.

Never as a default value sounds weird, so I proposed the switch to '---'.
Since the original implementation append a time elapse filter with ()
in the template, to make use of the changes in the filter
`scan_datetime` without hardcoding the `()` in the Javascript (that's a
presentation logic), I use `ng-show`.
