### PR TITLE
Fixed #93. Send login once invite is accepted to get last_login date.

### DIFF
--- a/minion/frontend/views.py
+++ b/minion/frontend/views.py
@@ -375,6 +375,9 @@ def persona_login():
         return jsonify(success=False)
     if request.json.get('invite_id'):
         user = accept_invite(receipt['email'], request.json)
+        if not user:
+            return jsonify(success=False)
+        user = login_or_create_user(user['email'])
     else:
         user = login_or_create_user(receipt['email'])
     if not user:


### PR DESCRIPTION
This fix might seem a waste for making a round trip. Well, the backend's
update_invite is monster and should be refactored to individual functions
to update both invite and user document. That being said, it isn't that
bad to make an extra round trip. It is a quick fix and actually does
reuse what has been implemented (login function in the frontend views
module).
