### PR TITLE
Cleanup templates by centralizing nav context creation.

### DIFF
--- a/minion/frontend/static/index.html
+++ b/minion/frontend/static/index.html
@@ -55,7 +55,9 @@
       </div>
     </div>
 
-    <ng-view></ng-view>
+    <div class="container">
+        <ng-view></ng-view>
+    </div>
 
     <p>&nbsp;</p>
 

--- a/minion/frontend/static/js/minion-admin.js
+++ b/minion/frontend/static/js/minion-admin.js
@@ -30,7 +30,7 @@ app.controller("AdminCreateUserController", function ($scope, dialog, users, gro
     };
 
     $scope.submit = function(user) {
-        if (_.find(users, function (u) { return u.email === user.email })) {
+        if (_.find(users, function (u) { return u.email === user.email; })) {
             $scope.error = "The user already exists.";
         } else {
             dialog.close(user);
@@ -42,6 +42,9 @@ app.controller("AdminCreateUserController", function ($scope, dialog, users, gro
 // users.html main controller
 // Dispatch dialog to use other controllers on action
 app.controller("AdminUsersController", function($scope, $http, $dialog) {
+
+    $scope.navItems = app.navContext('admin');
+
     var reload = function() {
         $http.get('/api/admin/users')
             .success(function(response, status, headers, config) {
@@ -122,6 +125,8 @@ app.controller("AdminCreateInviteController", function($scope, dialog, users, gr
         'accept': true,
         'decline': true
     };
+    $scope.navItems = app.navContext('admin');
+
     // todo: do cleanup!
     $scope.cancel = function() {
         dialog.close(null);
@@ -136,6 +141,9 @@ app.controller("AdminCreateInviteController", function($scope, dialog, users, gr
 
 // We don't want to refresh the page to see default orderBy to take place
 app.controller("AdminInvitesController", function($scope, $http, $dialog, $filter, $location) {
+
+    $scope.navItems = app.navContext('admin');
+
     var base_url = $location.absUrl().split("#!")[0] + '#!/invite';
     var reload = function() {
         $http.get('/api/admin/invites')
@@ -217,6 +225,9 @@ app.controller("AdminAddGroupController", function ($scope, dialog, group) {
 });
 
 app.controller("AdminGroupsController", function($scope, $routeParams, $http, $location, $dialog) {
+
+    $scope.navItems = app.navContext('admin');
+
     var reload = function () {
         $http.get('/api/admin/groups')
             .success(function(response, status, headers, config) {
@@ -291,6 +302,19 @@ app.controller("AdminAddSiteController", function ($scope, dialog, sites) {
 });
 
 app.controller("AdminGroupController", function($scope, $routeParams, $http, $location, $dialog) {
+
+    $scope.navItems = app.navContext('admin');
+
+    // TODO: This is incredibly hackish outside of what exists. We may
+    // need a better pattern for sub navigation.
+    var groupRoute = _.first(app.navContext('admin:groups'));
+    groupRoute.href = groupRoute.href.replace(
+                        /:groupName/, $routeParams.groupName);
+
+    // Insert the group nav item after the Groups parent nav.
+    var insertAt = _.indexOf(_.pluck($scope.navItems, 'slug'), 'groups') + 1;
+    $scope.navItems.splice(insertAt, 0, groupRoute);
+
     var reload = function () {
         $http.get('/api/admin/groups/' + $routeParams.groupName).success(function(response) {
             $scope.group = response.data;

--- a/minion/frontend/static/js/minion-main.js
+++ b/minion/frontend/static/js/minion-main.js
@@ -4,7 +4,26 @@
 
 var app = angular.module("MinionApp", ["ui.bootstrap", "minionAdminPlansModule", "minionAdminSitesModule", "minionAdminPluginsModule"]);
 
-app.controller("MinionController", function($rootScope, $scope, $http, $location) {
+
+// Return an array of controller sections, dependant on the 
+// `section` passed. Useful for easily compiling a navigation.
+app.navContext = function(section) {
+    return _.filter(app.navItems, function(route, url) {
+        return route.section === section;
+    });
+}
+
+app.controller("MinionController", function($rootScope, $route, $scope, $http, $location) {
+
+    // $route is useful in the scope for knowing "active" tabs, for example.
+    $rootScope.$route = $route;
+
+    // Compile all routes available to the application
+    app.navItems = _.map($route.routes, function(route, url) {
+        route.href = url;
+        return route;
+    });
+
     if (sessionStorage.getItem("email")) {
         $rootScope.session = {email: sessionStorage.getItem("email"), role: sessionStorage.getItem("role")};
     } else {
@@ -87,13 +106,56 @@ app.config(function($routeProvider, $locationProvider) {
         .when("/history", { templateUrl: "static/partials/history.html", controller: "HistoryController" })
         .when("/login", { templateUrl: "static/partials/login.html", controller: "LoginController" })
         // Administration
-        .when("/admin/sites", { templateUrl: "static/partials/admin/sites.html", controller: "AdminSitesController" })
-        .when("/admin/users", { templateUrl: "static/partials/admin/users.html", controller: "AdminUsersController" })
-        .when("/admin/groups", { templateUrl: "static/partials/admin/groups.html", controller: "AdminGroupsController" })
-        .when("/admin/groups/:groupName", { templateUrl: "static/partials/admin/group.html", controller: "AdminGroupController" })
-        .when("/admin/plugins", { templateUrl: "static/partials/admin/plugins/plugins.html", controller: "AdminPluginsController" })
-        .when("/admin/plans", { templateUrl: "static/partials/admin/plans/plans.html", controller: "AdminPlansController" })
-        .when("/admin/invites", { templateUrl: "static/partials/admin/invites.html", controller: "AdminInvitesController" });
+        .when("/admin/sites", {
+            section: "admin",
+            templateUrl: "static/partials/admin/sites.html",
+            controller: "AdminSitesController",
+            label: "Sites",
+            slug: "sites"
+        })
+        .when("/admin/users", {
+            section: "admin",
+            templateUrl: "static/partials/admin/users.html",
+            controller: "AdminUsersController",
+            label: "Users",
+            slug: "users"
+        })
+        .when("/admin/groups", {
+            section: "admin",
+            templateUrl: "static/partials/admin/groups.html",
+            controller: "AdminGroupsController",
+            label: "Groups",
+            slug: "groups"
+        })
+        // Sub nav of groups.
+        .when("/admin/groups/:groupName", {
+            section: "admin:groups",
+            templateUrl: "static/partials/admin/group.html",
+            controller: "AdminGroupController",
+            label: "Group Editor",
+            slug: "group"
+        })
+        .when("/admin/plugins", {
+            section: "admin",
+            templateUrl: "static/partials/admin/plugins/plugins.html",
+            controller: "AdminPluginsController",
+            label: "Plugins",
+            slug: "plugins"
+        })
+        .when("/admin/plans", {
+            section: "admin",
+            templateUrl: "static/partials/admin/plans/plans.html",
+            controller: "AdminPlansController",
+            label: "Plans",
+            slug: "plans"
+        })
+        .when("/admin/invites", {
+            section: "admin",
+            templateUrl: "static/partials/admin/invites.html",
+            controller: "AdminInvitesController",
+            label: "Invites",
+            slug: "invites"
+        });
 });
 
 app.run(function($rootScope, $http, $location) {

--- a/minion/frontend/static/js/minion/admin/plans.js
+++ b/minion/frontend/static/js/minion/admin/plans.js
@@ -97,6 +97,9 @@ minionAdminPlansModule.controller("AdminEditPlanController", function ($scope, d
 });
 
 minionAdminPlansModule.controller("AdminPlansController", function($scope, $routeParams, $http, $dialog) {
+
+    $scope.navItems = app.navContext('admin');
+
     var reload = function() {
         $http.get('/api/admin/plans').success(function(response) {
             $scope.plans = response.data;

--- a/minion/frontend/static/js/minion/admin/plugins.js
+++ b/minion/frontend/static/js/minion/admin/plugins.js
@@ -5,6 +5,9 @@
 var minionAdminPluginsModule = angular.module('minionAdminPluginsModule', []);
 
 minionAdminPluginsModule.controller("AdminPluginsController", function($scope, $routeParams, $http) {
+
+    $scope.navItems = app.navContext('admin');
+
     var reload = function() {
         $http.get('/api/admin/plugins')
             .success(function(response, status, headers, config) {

--- a/minion/frontend/static/js/minion/admin/sites.js
+++ b/minion/frontend/static/js/minion/admin/sites.js
@@ -35,6 +35,9 @@ minionAdminSitesModule.controller("AdminCreateSiteController", function ($scope,
 });
 
 minionAdminSitesModule.controller("AdminSitesController", function($scope, $routeParams, $http, $dialog) {
+
+    $scope.navItems = app.navContext('admin');
+
     var reload = function() {
         $http.get('/api/admin/sites')
             .success(function(response, status, headers, config) {

--- a/minion/frontend/static/partials/admin/group.html
+++ b/minion/frontend/static/partials/admin/group.html
@@ -1,20 +1,6 @@
-<div class="container" ng-controller="AdminGroupController">
-
-  <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/groups/{{group.name}}">Group Editor</a>
-    </li>
-  </ul>
-
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminGroupController">
+  
   <div class="row">
     <div class="span6">
       <h2>Group</h2>
@@ -70,5 +56,4 @@
       </table>
     </div>
   </div>
-
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/groups.html
+++ b/minion/frontend/static/partials/admin/groups.html
@@ -1,26 +1,5 @@
-<div class="container" ng-controller="AdminGroupsController">
-
-  <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-
-  </ul>
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminGroupsController">
 
 <h2>Groups</h2><span class="pull-right">
           Search: <input ng-model="query">  Sort by:
@@ -54,5 +33,4 @@
       </table>
     </div>
   </div>
-
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/invites.html
+++ b/minion/frontend/static/partials/admin/invites.html
@@ -1,26 +1,5 @@
-<div class="container" ng-controller="AdminInvitesController">
-
-   <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-
-  </ul> 
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminInvitesController">
 
   <h2>Invitations </h2><span class="pull-right">
           Search: <input ng-model="query">  Sort by:
@@ -66,4 +45,4 @@
     </div>
   </div>
 
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/nav.html
+++ b/minion/frontend/static/partials/admin/nav.html
@@ -1,0 +1,5 @@
+<ul class='nav nav-tabs'>
+    <li ng-repeat="nav in navItems" ng-class="{active: $route.current.slug == nav.slug}">
+        <a ng-href="#!{{nav.href}}">{{nav.label}}</a>
+    </li>
+</ul>

--- a/minion/frontend/static/partials/admin/plans/plans.html
+++ b/minion/frontend/static/partials/admin/plans/plans.html
@@ -1,25 +1,5 @@
-<div class="container" ng-controller="AdminGroupsController">
-
-  <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-  </ul>
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminPlansController">
 
 <h2>Plans</h2><span class="pull-right">
           Search: <input ng-model="query">  Sort by:
@@ -52,5 +32,4 @@
       </table>
     </div>
   </div>
-
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/plugins/plugins.html
+++ b/minion/frontend/static/partials/admin/plugins/plugins.html
@@ -1,25 +1,5 @@
-<div class="container" ng-controller="AdminPluginsController">
-
-  <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-  </ul>
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminPluginsController">
 
   <h2>Plugins</h2>
 <span class="pull-right">
@@ -48,5 +28,4 @@
       </table>
     </div>
   </div>
-
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/sites.html
+++ b/minion/frontend/static/partials/admin/sites.html
@@ -1,25 +1,5 @@
-<div class="container" ng-controller="AdminSitesController">
-
-    <ul class="nav nav-tabs">
-    <li>
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li class="active">
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-  </ul>
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminSitesController">
 
     <h2>Sites</h2><span class="pull-right">
           Search: <input ng-model="query">  Sort by:
@@ -58,4 +38,4 @@
     </div>
   </div>
 
-</div>
+</ng-controller>

--- a/minion/frontend/static/partials/admin/users.html
+++ b/minion/frontend/static/partials/admin/users.html
@@ -1,25 +1,5 @@
-<div class="container" ng-controller="AdminUsersController">
-
-  <ul class="nav nav-tabs">
-   <li class="active">
-      <a ng-href="#!/admin/users">Users</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/sites">Sites</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/groups">Groups</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plans">Plans</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/plugins">Plugins</a>
-    </li>
-    <li>
-      <a ng-href="#!/admin/invites">Invites</a>
-    </li>
-  </ul>
+<ng-include src="'static/partials/admin/nav.html'"></ng-include>
+<ng-controller="AdminUsersController">
 
 <h2>Users </h2><span class="pull-right">
           Search: <input ng-model="query">  Sort by:
@@ -63,4 +43,4 @@
     </div>
   </div>
 
-</div>
+</ng-controller>


### PR DESCRIPTION
Initially looked into the low hanging fruit of Issue #86, but
decided it makes sense to do some refactoring here, to make the templates more
DRY, and provide sanity moving forward. Primary adjustments are:
- Compile all routes into an app.navItems variable
- Introduce app.navContext, allowing us to easily get the navigation
  items for a specific "section" of the site
- Adjust the controller to contain more variables that are useful
  in rendering a nav.

I am completely new to AngularJS, infact -- this is the first time I ever
touched it! So, there are some issues. For example, in `AdminGroupController`
we need a sub nav for the "Group Editor". The implementation of adding
this to the nav feels very hackish and perhaps we can implement
some notion of sub navigation. However, this may not be required right now
given the simplicity of the admin, so perhaps it's ok for the current
implementation.

Either way, happy to hear your feedback on this, and what I can improve on before merge. :)
