### PR TITLE
declare_namespace in __init__.py

### DIFF
--- a/minion/__init__.py
+++ b/minion/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
I was just running the instructions at https://github.com/mozilla/minion#setting-up-a-development-environment and was hitting this failure:

```
running develop
running egg_info
creating minion.frontend.egg-info
writing requirements to minion.frontend.egg-info/requires.txt
writing minion.frontend.egg-info/PKG-INFO
writing namespace_packages to minion.frontend.egg-info/namespace_packages.txt
writing top-level names to minion.frontend.egg-info/top_level.txt
writing dependency_links to minion.frontend.egg-info/dependency_links.txt
writing manifest file 'minion.frontend.egg-info/SOURCES.txt'
error: Namespace package problem: minion is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
```

So, I believe this PR is what is missing from `minion-frontend`.